### PR TITLE
Fix "duplicate behviour" error due to EventListener having no name

### DIFF
--- a/fml-parser/src/main/java/org/openflexo/foundation/fml/parser/fmlnodes/EventListenerNode.java
+++ b/fml-parser/src/main/java/org/openflexo/foundation/fml/parser/fmlnodes/EventListenerNode.java
@@ -93,6 +93,12 @@ public class EventListenerNode extends FlexoBehaviourNode<AListenerBehaviourDecl
 			throwIssue("Unexpected event type: " + astNode.getEventType());
 		}
 
+		try {
+			returned.setName(type.getTypeName());
+		} catch (InvalidNameException e) {
+			throwIssue("Cannot set EventListener event type name: " + astNode.getEventType());
+		}
+
 		PExpression fromExpression = astNode.getListened();
 		DataBinding<VirtualModelInstance<?, ?>> listened = (DataBinding) ExpressionFactory.makeDataBinding(fromExpression, returned,
 				BindingDefinitionType.GET, VirtualModelInstance.class, getSemanticsAnalyzer(), this);

--- a/fml-parser/src/main/java/org/openflexo/foundation/fml/parser/fmlnodes/EventListenerNode.java
+++ b/fml-parser/src/main/java/org/openflexo/foundation/fml/parser/fmlnodes/EventListenerNode.java
@@ -93,16 +93,16 @@ public class EventListenerNode extends FlexoBehaviourNode<AListenerBehaviourDecl
 			throwIssue("Unexpected event type: " + astNode.getEventType());
 		}
 
-		try {
-			returned.setName(type.getTypeName());
-		} catch (InvalidNameException e) {
-			throwIssue("Cannot set EventListener event type name: " + astNode.getEventType());
-		}
-
 		PExpression fromExpression = astNode.getListened();
 		DataBinding<VirtualModelInstance<?, ?>> listened = (DataBinding) ExpressionFactory.makeDataBinding(fromExpression, returned,
 				BindingDefinitionType.GET, VirtualModelInstance.class, getSemanticsAnalyzer(), this);
 		returned.setListenedVirtualModelInstance(listened);
+
+		try {
+			returned.setName(type.getTypeName() + " from " + astNode.getListened());
+		} catch (InvalidNameException e) {
+			throwIssue("Cannot set EventListenr event type name: " + astNode.getEventType());
+		}
 
 		PFlexoBehaviourBody flexoBehaviourBody = getFlexoBehaviourBody(astNode);
 		if (flexoBehaviourBody instanceof ABlockFlexoBehaviourBody) {


### PR DESCRIPTION
During FML parsing, when multiple EventListener was declared in the same model it always triggered a "Duplicate behaviour" verification error.

This was due to the behaviour signature being "null(event)" for all EventListener nodes during parsing and object creation. This PR add the event name and listened instance as the behaviour name.