### PR TITLE
Events not triggered in SynchronousFMLRunTimeEngine

### DIFF
--- a/flexo-foundation/src/main/java/org/openflexo/foundation/fml/rt/SynchronousFMLRunTimeEngine.java
+++ b/flexo-foundation/src/main/java/org/openflexo/foundation/fml/rt/SynchronousFMLRunTimeEngine.java
@@ -69,7 +69,7 @@ public class SynchronousFMLRunTimeEngine extends DefaultFMLRunTimeEngine {
 			Set<EventInstanceListener> listeners = listeningInstances.get(event.getSourceVirtualModelInstance());
 			if (listeners != null) {
 				for (EventInstanceListener l : new ArrayList<>(listeners)) {
-					if (l.getListener().getEvent().isAssignableFrom(event.getFlexoEvent())) {
+					if (l.getListener().getEvent().getName().equals(event.getFlexoEvent().getName())) {
 						fireEventListener(l.getInstanceBeeingListening(), l.getListener(), event);
 					}
 				}


### PR DESCRIPTION
On my 2.99 instance, events were not always triggered properly. After code inspection, this issue was due to a condition in SynchronousFMLRunTimeEngine that wasn't matching the event as intended.

The proposed fix is to be discussed, as using the event name is maybe unsafe and can lead to unexpected results. It's working for now on my machine.

What do you think about this implementation @sylvain-openflexo ?
