### PR TITLE
Feature: Execute FML script in CLI

### DIFF
--- a/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/AbstractCommandSemanticsAnalyzer.java
+++ b/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/AbstractCommandSemanticsAnalyzer.java
@@ -56,6 +56,7 @@ import org.openflexo.foundation.fml.parser.node.AAssignmentExpression;
 import org.openflexo.foundation.fml.parser.node.ACdDirective;
 import org.openflexo.foundation.fml.parser.node.AContextFmlCommand;
 import org.openflexo.foundation.fml.parser.node.AEnterDirective;
+import org.openflexo.foundation.fml.parser.node.AExecuteDirective;
 import org.openflexo.foundation.fml.parser.node.AExitDirective;
 import org.openflexo.foundation.fml.parser.node.AExpressionFmlCommand;
 import org.openflexo.foundation.fml.parser.node.AFmlActionFmlCommand;
@@ -150,6 +151,12 @@ public abstract class AbstractCommandSemanticsAnalyzer extends FMLSemanticsAnaly
 	public void outALsDirective(ALsDirective node) {
 		super.outALsDirective(node);
 		registerCommand(node, scriptModelFactory.newLsDirective(node, this));
+	}
+	
+	@Override
+	public void outAExecuteDirective(AExecuteDirective node) {
+		super.outAExecuteDirective(node);
+		registerCommand(node, scriptModelFactory.newExecuteDirective(node, this));
 	}
 
 	@Override

--- a/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/AbstractCommand.java
+++ b/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/AbstractCommand.java
@@ -57,6 +57,7 @@ import org.openflexo.foundation.fml.cli.ScriptSemanticsAnalyzer;
 import org.openflexo.foundation.fml.cli.command.directive.ActivateTA;
 import org.openflexo.foundation.fml.cli.command.directive.CdDirective;
 import org.openflexo.foundation.fml.cli.command.directive.EnterDirective;
+import org.openflexo.foundation.fml.cli.command.directive.ExecuteDirective;
 import org.openflexo.foundation.fml.cli.command.directive.ExitDirective;
 import org.openflexo.foundation.fml.cli.command.directive.HelpDirective;
 import org.openflexo.foundation.fml.cli.command.directive.HistoryDirective;
@@ -106,7 +107,7 @@ import org.openflexo.pamela.annotations.Setter;
 		@Import(ServiceDirective.class), @Import(ActivateTA.class), @Import(ResourcesDirective.class), @Import(OpenProject.class),
 		@Import(LoadResource.class), @Import(MoreDirective.class), @Import(EnterDirective.class), @Import(ExitDirective.class),
 		@Import(FMLContextCommand.class), @Import(FMLExpression.class), @Import(FMLAssignation.class), @Import(FMLAssertExpression.class),
-		@Import(FMLActionCommand.class) })
+		@Import(FMLActionCommand.class), @Import(ExecuteDirective.class) })
 public interface AbstractCommand<N extends Node> extends Bindable, FMLControlGraphOwner {
 
 	@PropertyIdentifier(type = Node.class)

--- a/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/Directive.java
+++ b/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/Directive.java
@@ -41,6 +41,7 @@ package org.openflexo.foundation.fml.cli.command;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Executable;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -52,6 +53,7 @@ import org.openflexo.foundation.FlexoObject;
 import org.openflexo.foundation.fml.cli.command.directive.ActivateTA;
 import org.openflexo.foundation.fml.cli.command.directive.CdDirective;
 import org.openflexo.foundation.fml.cli.command.directive.EnterDirective;
+import org.openflexo.foundation.fml.cli.command.directive.ExecuteDirective;
 import org.openflexo.foundation.fml.cli.command.directive.ExitDirective;
 import org.openflexo.foundation.fml.cli.command.directive.HelpDirective;
 import org.openflexo.foundation.fml.cli.command.directive.HistoryDirective;
@@ -136,7 +138,7 @@ import org.openflexo.toolbox.StringUtils;
 		@DeclareDirective(QuitDirective.class), @DeclareDirective(ServicesDirective.class), @DeclareDirective(ServiceDirective.class),
 		@DeclareDirective(ActivateTA.class), @DeclareDirective(ResourcesDirective.class), @DeclareDirective(OpenProject.class),
 		@DeclareDirective(LoadResource.class), @DeclareDirective(MoreDirective.class), @DeclareDirective(EnterDirective.class),
-		@DeclareDirective(ExitDirective.class) })
+		@DeclareDirective(ExitDirective.class), @DeclareDirective(ExecuteDirective.class) })
 public interface Directive<N extends Node> extends AbstractCommand<N> {
 
 	public static abstract class DirectiveImpl<N extends Node> extends AbstractCommandImpl<N> {

--- a/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/FMLScriptModelFactory.java
+++ b/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/FMLScriptModelFactory.java
@@ -43,6 +43,7 @@ import org.openflexo.foundation.fml.cli.ScriptSemanticsAnalyzer;
 import org.openflexo.foundation.fml.cli.command.directive.ActivateTA;
 import org.openflexo.foundation.fml.cli.command.directive.CdDirective;
 import org.openflexo.foundation.fml.cli.command.directive.EnterDirective;
+import org.openflexo.foundation.fml.cli.command.directive.ExecuteDirective;
 import org.openflexo.foundation.fml.cli.command.directive.ExitDirective;
 import org.openflexo.foundation.fml.cli.command.directive.HelpDirective;
 import org.openflexo.foundation.fml.cli.command.directive.HistoryDirective;
@@ -66,6 +67,7 @@ import org.openflexo.foundation.fml.parser.node.AAssignmentExpression;
 import org.openflexo.foundation.fml.parser.node.ACdDirective;
 import org.openflexo.foundation.fml.parser.node.AContextFmlCommand;
 import org.openflexo.foundation.fml.parser.node.AEnterDirective;
+import org.openflexo.foundation.fml.parser.node.AExecuteDirective;
 import org.openflexo.foundation.fml.parser.node.AExitDirective;
 import org.openflexo.foundation.fml.parser.node.AExpressionFmlCommand;
 import org.openflexo.foundation.fml.parser.node.AFmlActionFmlCommand;
@@ -125,6 +127,10 @@ public class FMLScriptModelFactory extends PamelaModelFactory {
 
 	public LsDirective newLsDirective(ALsDirective node, AbstractCommandSemanticsAnalyzer semanticsAnalyzer) {
 		return newInstance(LsDirective.class, node, semanticsAnalyzer);
+	}
+	
+	public ExecuteDirective newExecuteDirective(AExecuteDirective node, AbstractCommandSemanticsAnalyzer semanticsAnalyzer) {
+		return newInstance(ExecuteDirective.class, node, semanticsAnalyzer);
 	}
 
 	public MoreDirective newMoreDirective(AMoreDirective node, AbstractCommandSemanticsAnalyzer semanticsAnalyzer) {

--- a/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/directive/ExecuteDirective.java
+++ b/fml-cli/src/main/java/org/openflexo/foundation/fml/cli/command/directive/ExecuteDirective.java
@@ -1,0 +1,143 @@
+/**
+ * 
+ * Copyright (c) 2013-2014, Openflexo
+ * 
+ * This file is part of openflexo-core, a component of the software infrastructure 
+ * developed at Openflexo.
+ * 
+ * 
+ * Openflexo is dual-licensed under the European Union Public License (EUPL, either 
+ * version 1.1 of the License, or any later version ), which is available at 
+ * https://joinup.ec.europa.eu/software/page/eupl/licence-eupl
+ * and the GNU General Public License (GPL, either version 3 of the License, or any 
+ * later version), which is available at http://www.gnu.org/licenses/gpl.html .
+ * 
+ * You can redistribute it and/or modify under the terms of either of these licenses
+ * 
+ * If you choose to redistribute it and/or modify under the terms of the GNU GPL, you
+ * must include the following additional permission.
+ *
+ *          Additional permission under GNU GPL version 3 section 7
+ *
+ *          If you modify this Program, or any covered work, by linking or 
+ *          combining it with software containing parts covered by the terms 
+ *          of EPL 1.0, the licensors of this Program grant you additional permission
+ *          to convey the resulting work. * 
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT ANY 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE. 
+ *
+ * See http://www.openflexo.org/license.html for details.
+ * 
+ * 
+ * Please contact Openflexo (openflexo-contacts@openflexo.org)
+ * or visit www.openflexo.org if you need additional information.
+ * 
+ */
+
+package org.openflexo.foundation.fml.cli.command.directive;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;import org.openflexo.foundation.fml.FMLModelFactory;
+import org.openflexo.foundation.fml.cli.AbstractCommandSemanticsAnalyzer;
+import org.openflexo.foundation.fml.cli.FMLScriptParser;
+import org.openflexo.foundation.fml.cli.ParseException;
+import org.openflexo.foundation.fml.cli.command.Directive;
+import org.openflexo.foundation.fml.cli.command.DirectiveDeclaration;
+import org.openflexo.foundation.fml.cli.command.FMLCommandExecutionException;
+import org.openflexo.foundation.fml.cli.command.FMLScript;
+import org.openflexo.foundation.fml.parser.node.ACdDirective;
+import org.openflexo.foundation.fml.parser.node.AExecuteDirective;
+import org.openflexo.pamela.annotations.ImplementationClass;
+import org.openflexo.pamela.annotations.ModelEntity;
+import org.openflexo.pamela.exceptions.ModelDefinitionException;
+import org.openflexo.rm.Resource;
+import org.openflexo.rm.ResourceLocator;
+import org.openflexo.toolbox.StringUtils;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+/**
+ * Represents #execute directive in FML command-line interpreter
+ * 
+ * Usage: #execute
+ * 
+ * @author fledoux
+ * 
+ */
+@ModelEntity
+@ImplementationClass(ExecuteDirective.ExecuteDirectiveImpl.class)
+@DirectiveDeclaration(keyword = "execute", usage = "execute", description = "Execute a FMLscript in the context", syntax = "execute <fmlscript file path>")
+public interface ExecuteDirective extends Directive<AExecuteDirective> {
+
+	public static abstract class ExecuteDirectiveImpl extends DirectiveImpl<AExecuteDirective> implements ExecuteDirective {
+		
+		@SuppressWarnings("unused")
+		private static final Logger logger = Logger.getLogger(ExecuteDirective.class.getPackage().getName());
+
+		private String scriptPath;
+		
+		@Override
+		public void create(AExecuteDirective node, AbstractCommandSemanticsAnalyzer commandSemanticsAnalyzer) {
+			performSuperInitializer(node, commandSemanticsAnalyzer);
+			scriptPath = retrievePath(node.getPath());
+		}
+		
+		@Override
+		public String toString() {
+			return "execute "  + scriptPath;
+		}
+		
+		public File getScriptFile() {
+			File scriptFile;
+			// TODO Unix only
+			if (scriptPath.startsWith("/")) {
+				scriptFile = new File(scriptPath);
+			} else {
+				scriptFile = new File(getCommandInterpreter().getWorkingDirectory(), scriptPath);
+			}
+			return scriptFile;
+		}
+		
+		@Override
+		public boolean isSyntaxicallyValid() {
+			return StringUtils.isNotEmpty(scriptPath);
+		}
+		
+		@Override
+		public String invalidCommandReason() {
+			if (scriptPath == null) {
+				return "No directory";
+			}
+			// Check if it's a file			
+			else if (getScriptFile().exists() && getScriptFile().isFile()) {
+				return "Cannot find script file: " + getScriptFile().getName();
+			}			
+			return null;
+		}
+
+		@Override
+		public Object execute() throws FMLCommandExecutionException {
+			super.execute();
+			output.clear();
+			try {
+				FMLScriptParser parser = new FMLScriptParser();
+				FileInputStream scriptStream = new FileInputStream(getScriptFile());
+				FMLScript script = parser.parse(scriptStream, getCommandInterpreter().getModelFactory(), getCommandInterpreter());
+				script.execute();
+			} catch (ParseException e) {
+				getOutStream().println("Error during script parsing : " + e.getMessage());
+			} catch (FileNotFoundException e) {
+				getOutStream().println("Script file was not found : " + e.getMessage());
+			} catch (IOException e) {
+				getOutStream().println("Error during script execution : " + e.getMessage());
+			} catch (ModelDefinitionException e) {
+				getOutStream().println("Model definitnio error during script execution : " + e.getMessage());
+			}
+
+			return getCommandInterpreter().getWorkingDirectory();
+		}
+	}
+}

--- a/fml-parser/src/main/sablecc/fml.sablecc
+++ b/fml-parser/src/main/sablecc/fml.sablecc
@@ -218,6 +218,7 @@ Tokens
 
    {command,script} help = 'help';
    {command,script} history = 'history';
+   {command,script} execute = 'execute';
    {command,script} pwd = 'pwd';
    {command,script} ls = 'ls';
    {command,script} cd = 'cd';
@@ -384,6 +385,7 @@ Productions
      {pwd}         pwd |
      {ls}          ls |
      {cd}          cd path |
+     {execute}     execute path |
      {services}    services |
      {service}     service [service_name]:identifier [action]:identifier [argument]:directive_argument? |
      {activate_ta} activate [technology_adapter]:identifier |


### PR DESCRIPTION
This PR add a new feature that allows FML script execution inside the FML CLI. The script is executed inside the context of the command interpreter. 

The command is named "execute" and the syntax is "execute <script_path>"

I didn't add unit tests for this feature sorry (I'm not used to the testing environment of the project).

@sylvain-openflexo  What do you think about adding this feature in Openflexo ?